### PR TITLE
Add Django 2 and Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: python
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+  # django22 and django-master can only be installed into xenial images
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.6
+      env: DIST=trusty
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      env: DIST=xenial
+    - python: 2.7
+    - python: 3.5
+    - python: 3.4
+    # tox and tox-travis refuse to run on Python 3.3
+    # Also various versions of Django on Python 3.3 are reporting
+    # django/utils/html_parser.py: AttributeError: module 'html.parser' has no attribute 'HTMLParseError'
+    - python: 3.5
+      env: TOX_ENV=py35-django22
+      install: pip install tox
+      dist: xenial
+      sudo: true
+    - python: 3.6
+      env: TOX_ENV=py36-django22
+      install: pip install tox
+      dist: xenial
+      sudo: true
+    - python: 3.6
+      env: TOX_ENV=py36-django-master
+      install: pip install tox
+      dist: xenial
+      sudo: true
+    - python: 3.7
+      env: TOX_ENV=py37-django-master
+      install: pip install tox
+      dist: xenial
+      sudo: true
+  allow_failures:
+    - env: TOX_ENV=py36-django-master
+    - env: TOX_ENV=py37-django-master
+
+install:
+  - pip install tox-travis
+
+script:
+  - tox

--- a/examples/requirements/django_1_10.txt
+++ b/examples/requirements/django_1_10.txt
@@ -1,3 +1,5 @@
+pytest>=3.0.2
+
 -r base.txt
 
 Django>=1.10,<1.11

--- a/examples/requirements/django_1_11.txt
+++ b/examples/requirements/django_1_11.txt
@@ -1,3 +1,5 @@
+pytest>=3.0.2
+
 -r base.txt
 
 #Django>=1.11,<2.0

--- a/examples/requirements/django_1_4.txt
+++ b/examples/requirements/django_1_4.txt
@@ -1,3 +1,5 @@
+pytest==3.0.2
+
 -r base.txt
 
 Django>=1.4,<1.5

--- a/examples/requirements/django_1_5.txt
+++ b/examples/requirements/django_1_5.txt
@@ -1,3 +1,5 @@
+pytest==3.0.2
+
 -r base.txt
 
 Django>=1.5,<1.6

--- a/examples/requirements/django_1_6.txt
+++ b/examples/requirements/django_1_6.txt
@@ -1,3 +1,5 @@
+pytest==3.0.2
+
 -r base.txt
 
 Django>=1.6,<1.7

--- a/examples/requirements/django_1_7.txt
+++ b/examples/requirements/django_1_7.txt
@@ -1,3 +1,5 @@
+pytest==3.0.2
+
 -r base.txt
 
 Django>=1.7,<1.8

--- a/examples/requirements/django_1_8.txt
+++ b/examples/requirements/django_1_8.txt
@@ -1,3 +1,5 @@
+pytest>=3.0.2
+
 -r base.txt
 
 Django>=1.8,<1.9

--- a/examples/requirements/django_1_9.txt
+++ b/examples/requirements/django_1_9.txt
@@ -1,3 +1,5 @@
+pytest>=3.0.2
+
 -r base.txt
 
 Django>=1.9,<1.10

--- a/examples/requirements/django_2_0.txt
+++ b/examples/requirements/django_2_0.txt
@@ -1,0 +1,6 @@
+pytest>=3.0.2
+
+-r base.txt
+
+Django>=2.0,<2.1
+sqlparse

--- a/examples/requirements/django_2_1.txt
+++ b/examples/requirements/django_2_1.txt
@@ -1,0 +1,6 @@
+pytest>=3.0.2
+
+-r base.txt
+
+Django>=2.1,<2.2
+sqlparse

--- a/examples/requirements/django_2_2.txt
+++ b/examples/requirements/django_2_2.txt
@@ -1,0 +1,5 @@
+pytest>=3.0.2
+
+-r base.txt
+
+Django>=2.2,<2.3

--- a/examples/requirements/testing.txt
+++ b/examples/requirements/testing.txt
@@ -1,6 +1,8 @@
+# pytest==3.0.2 or pytest>=3.0.2 depends on Django version
+# and is set in those requirements files
+
 factory_boy==2.7.0
 fake-factory==0.7.2
-pytest==3.0.2
-pytest-django==2.9.1
-pytest-cov==2.2.1
+pytest-django>=2.9.1
+pytest-cov>=2.2.1
 tox==2.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,22 @@
 [tox]
 envlist =
-    py{26,27,34}-{django15,django16},
-    py{27,34}-{django17},
+    py{26,27,34}-{django15,django16}
+    py{27,34}-{django17}
     py{27,34,35,36}-{django18,django19,django110,django111}
+    py{34,35,36}-{django20}
+    py{35,36,37}-{django21,django22,django-master}
+
+[travis]
+# Django <= 1.7 are excluded due to pytest versions.
+# Django master are excluded so they can fail.
+# django22 & django-master & Python 3.7 need to be run in xenial,
+# so these entries prevent them being run together with non-xenial jobs.
+python =
+  2.7: py27-django18,py27-django19,py27-django110,py27-django111
+  3.4: py34-django18,py34-django19,py34-django110,py34-django111,py34-django20
+  3.5: py35-django18,py35-django19,py35-django110,py35-django111,py35-django20,py35-django21
+  3.6: py36-django18,py36-django19,py36-django110,py36-django111,py36-django20,py36-django21
+  3.7: py37-django21,py37-django22
 
 [testenv]
 envlogdir=examples/var/logs/
@@ -15,6 +29,11 @@ deps =
     django19: -r{toxinidir}/examples/requirements/django_1_9.txt
     django110: -r{toxinidir}/examples/requirements/django_1_10.txt
     django111: -r{toxinidir}/examples/requirements/django_1_11.txt
+    django20: -r{toxinidir}/examples/requirements/django_2_0.txt
+    django21: -r{toxinidir}/examples/requirements/django_2_1.txt
+    django22: -r{toxinidir}/examples/requirements/django_2_2.txt
+    django-master: https://github.com/django/django/archive/master.tar.gz
+    django-master: -r{toxinidir}/examples/requirements/base.txt
 
 commands =
 #    {envpython} examples/simple/manage.py test {posargs:nine} --settings=simple.settings_test --traceback -v 3


### PR DESCRIPTION
Add .travis.yml with a rather large matrix using tox-travis
testing only Django >= 1.8, and letting the pytest version
float as older pytest are not compatible with newer Django
or Python version.

Jobs for Django master are included but allowed to fail.

Adjust Django <=1.7 to keep the pin on pytest==3.0.2
however that will not work on many Python versions.